### PR TITLE
Event interface

### DIFF
--- a/EgoEvents.cs
+++ b/EgoEvents.cs
@@ -17,6 +17,12 @@ public static class EgoEvents
 		get { return _unorderedEvents; }
 	}
 
+	static Dictionary<Type, Action<IEgoEvent>> _addEventLookup = new Dictionary<Type, Action<IEgoEvent>>();
+	public static Dictionary<Type, Action<IEgoEvent>> addEventLookup
+	{
+		get { return _addEventLookup; }
+	}
+
 	static Dictionary<Type, Action> _invokeLookup = new Dictionary<Type, Action>();
 	public static Dictionary<Type, Action> invokeLookup
 	{
@@ -66,6 +72,12 @@ public static class EgoEvents
 		_userOrderedLastEvents.Add( e );
 	}
 
+	public static void AddEvent( IEgoEvent e )
+	{
+		var t = e.GetType();
+		_addEventLookup[ t ]( e );
+	}
+
 	static void MakeEventInvoke( Type eventType )
 	{
 		var fullEventType = typeof( EgoEvents<> ).MakeGenericType( eventType );
@@ -105,6 +117,7 @@ public static class EgoEvents<E>
 	{
 		var e = typeof( E );
 
+		EgoEvents.addEventLookup[ e ] = AddBaseEvent;
 		EgoEvents.invokeLookup[ e ] = Invoke;
 		EgoEvents.unorderedEvents.Add( e );
 	}
@@ -147,5 +160,10 @@ public static class EgoEvents<E>
 	public static void AddEvent( E e )
 	{
 		_events.Add( e );
+	}
+
+	private static void AddBaseEvent( IEgoEvent e )
+	{
+		_events.Add( (E)e );
 	}
 }

--- a/EgoEvents.cs
+++ b/EgoEvents.cs
@@ -29,7 +29,7 @@ public static class EgoEvents
 		{
 			foreach( var type in assembly.GetTypes() )
 			{
-				if( type.IsSubclassOf( typeof( EgoEvent ) ) && !type.IsAbstract && !type.IsGenericType )
+				if( type.IsSubclassOf( typeof( IEgoEvent ) ) && !type.IsAbstract && !type.IsGenericType )
 				{
 					MakeEventInvoke( type );
 				}
@@ -54,13 +54,13 @@ public static class EgoEvents
 		_unorderedEvents.ExceptWith( _lastEvents );
 	}
 
-	public static void AddFront<E>() where E : EgoEvent
+	public static void AddFront<E>() where E : IEgoEvent
 	{
 		var e = typeof( E );
 		_userOrderedFirstEvents.Add( e );
 	}
 
-	public static void AddEnd<E>() where E : EgoEvent
+	public static void AddEnd<E>() where E : IEgoEvent
 	{
 		var e = typeof( E );
 		_userOrderedLastEvents.Add( e );
@@ -91,7 +91,7 @@ public static class EgoEvents
 }
 
 public static class EgoEvents<E>
-	where E : EgoEvent
+	where E : IEgoEvent
 {
 	static List<E> _events = new List<E>();
 	static List<Action<E>> _handlers = new List<Action<E>>();

--- a/Events/AddedComponent.cs
+++ b/Events/AddedComponent.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-public abstract class AddedComponent : EgoEvent{}
+public abstract class AddedComponent : IEgoEvent{}
 
 public class AddedComponent<C> : AddedComponent
     where C : Component

--- a/Events/AddedGameObject.cs
+++ b/Events/AddedGameObject.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-public class AddedGameObject : EgoEvent
+public class AddedGameObject : IEgoEvent
 {
     public readonly GameObject gameObject;
     public readonly EgoComponent egoComponent;

--- a/Events/DestroyedComponent.cs
+++ b/Events/DestroyedComponent.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-public abstract class DestroyedComponent : EgoEvent { }
+public abstract class DestroyedComponent : IEgoEvent { }
 
 public class DestroyedComponent<C> : DestroyedComponent
     where C : Component

--- a/Events/DestroyedGameObject.cs
+++ b/Events/DestroyedGameObject.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-public class DestroyedGameObject : EgoEvent
+public class DestroyedGameObject : IEgoEvent
 {
     public readonly GameObject gameObject;
     public readonly EgoComponent egoComponent;

--- a/Events/EgoEvent.cs
+++ b/Events/EgoEvent.cs
@@ -1,1 +1,0 @@
-﻿public abstract class EgoEvent { }

--- a/Events/IEgoEvent.cs
+++ b/Events/IEgoEvent.cs
@@ -1,0 +1,1 @@
+﻿public interface IEgoEvent { }

--- a/Events/IEgoEvent.cs.meta
+++ b/Events/IEgoEvent.cs.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: 623b69939526ed84c87ed3baf6cb18e3
-timeCreated: 1445223866
+guid: ba9a70838c657af499e7f930775b6439
+timeCreated: 1502883423
 licenseType: Free
 MonoImporter:
   serializedVersion: 2

--- a/Events/MonoBehavior Messages/CollisionEnter.cs
+++ b/Events/MonoBehavior Messages/CollisionEnter.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-public class CollisionEnterEvent : EgoEvent
+public class CollisionEnterEvent : IEgoEvent
 {
     public readonly EgoComponent egoComponent1;
     public readonly EgoComponent egoComponent2;

--- a/Events/MonoBehavior Messages/CollisionEnter2D.cs
+++ b/Events/MonoBehavior Messages/CollisionEnter2D.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-public class CollisionEnter2DEvent : EgoEvent
+public class CollisionEnter2DEvent : IEgoEvent
 {
     public readonly EgoComponent egoComponent1;
     public readonly EgoComponent egoComponent2;

--- a/Events/MonoBehavior Messages/CollisionExit.cs
+++ b/Events/MonoBehavior Messages/CollisionExit.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-public class CollisionExitEvent : EgoEvent
+public class CollisionExitEvent : IEgoEvent
 {
     public readonly EgoComponent egoComponent1;
     public readonly EgoComponent egoComponent2;

--- a/Events/MonoBehavior Messages/CollisionExit2D.cs
+++ b/Events/MonoBehavior Messages/CollisionExit2D.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-public class CollisionExit2DEvent : EgoEvent
+public class CollisionExit2DEvent : IEgoEvent
 {
     public readonly EgoComponent egoComponent1;
     public readonly EgoComponent egoComponent2;

--- a/Events/MonoBehavior Messages/CollisionStay.cs
+++ b/Events/MonoBehavior Messages/CollisionStay.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-public class CollisionStayEvent : EgoEvent
+public class CollisionStayEvent : IEgoEvent
 {
     public readonly EgoComponent egoComponent1;
     public readonly EgoComponent egoComponent2;

--- a/Events/MonoBehavior Messages/CollisionStay2D.cs
+++ b/Events/MonoBehavior Messages/CollisionStay2D.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-public class CollisionStay2DEvent : EgoEvent
+public class CollisionStay2DEvent : IEgoEvent
 {
     public readonly EgoComponent egoComponent1;
     public readonly EgoComponent egoComponent2;

--- a/Events/MonoBehavior Messages/MouseDown.cs
+++ b/Events/MonoBehavior Messages/MouseDown.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-public class MouseDownEvent : EgoEvent
+public class MouseDownEvent : IEgoEvent
 {
 	public readonly EgoComponent egoComponent;
 

--- a/Events/MonoBehavior Messages/MouseDrag.cs
+++ b/Events/MonoBehavior Messages/MouseDrag.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-public class MouseDragEvent : EgoEvent
+public class MouseDragEvent : IEgoEvent
 {
 	public readonly EgoComponent egoComponent;
 

--- a/Events/MonoBehavior Messages/MouseEnter.cs
+++ b/Events/MonoBehavior Messages/MouseEnter.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-public class MouseEnterEvent : EgoEvent
+public class MouseEnterEvent : IEgoEvent
 {
 	public readonly EgoComponent egoComponent;
 

--- a/Events/MonoBehavior Messages/MouseExit.cs
+++ b/Events/MonoBehavior Messages/MouseExit.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-public class MouseExitEvent : EgoEvent
+public class MouseExitEvent : IEgoEvent
 {
 	public readonly EgoComponent egoComponent;
 

--- a/Events/MonoBehavior Messages/MouseUp.cs
+++ b/Events/MonoBehavior Messages/MouseUp.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-public class MouseUpEvent : EgoEvent
+public class MouseUpEvent : IEgoEvent
 {
 	public readonly EgoComponent egoComponent;
 

--- a/Events/MonoBehavior Messages/MouseUpAsButton.cs
+++ b/Events/MonoBehavior Messages/MouseUpAsButton.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-public class MouseUpAsButtonEvent : EgoEvent
+public class MouseUpAsButtonEvent : IEgoEvent
 {
 	public readonly EgoComponent egoComponent;
 

--- a/Events/MonoBehavior Messages/TriggerEnter.cs
+++ b/Events/MonoBehavior Messages/TriggerEnter.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-public class TriggerEnterEvent : EgoEvent
+public class TriggerEnterEvent : IEgoEvent
 {
     public readonly EgoComponent egoComponent1;
     public readonly EgoComponent egoComponent2;

--- a/Events/MonoBehavior Messages/TriggerEnter2D.cs
+++ b/Events/MonoBehavior Messages/TriggerEnter2D.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-public class TriggerEnter2DEvent : EgoEvent
+public class TriggerEnter2DEvent : IEgoEvent
 {
     public readonly EgoComponent egoComponent1;
     public readonly EgoComponent egoComponent2;

--- a/Events/MonoBehavior Messages/TriggerExit.cs
+++ b/Events/MonoBehavior Messages/TriggerExit.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-public class TriggerExitEvent : EgoEvent
+public class TriggerExitEvent : IEgoEvent
 {
     public readonly EgoComponent egoComponent1;
     public readonly EgoComponent egoComponent2;

--- a/Events/MonoBehavior Messages/TriggerExit2D.cs
+++ b/Events/MonoBehavior Messages/TriggerExit2D.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-public class TriggerExit2DEvent : EgoEvent
+public class TriggerExit2DEvent : IEgoEvent
 {
     public readonly EgoComponent egoComponent1;
     public readonly EgoComponent egoComponent2;

--- a/Events/MonoBehavior Messages/TriggerStay.cs
+++ b/Events/MonoBehavior Messages/TriggerStay.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-public class TriggerStayEvent : EgoEvent
+public class TriggerStayEvent : IEgoEvent
 {
     public readonly EgoComponent egoComponent1;
     public readonly EgoComponent egoComponent2;

--- a/Events/MonoBehavior Messages/TriggerStay2D.cs
+++ b/Events/MonoBehavior Messages/TriggerStay2D.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-public class TriggerStay2DEvent : EgoEvent
+public class TriggerStay2DEvent : IEgoEvent
 {
     public readonly EgoComponent egoComponent1;
     public readonly EgoComponent egoComponent2;

--- a/Events/SetParent.cs
+++ b/Events/SetParent.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-public class SetParent : EgoEvent
+public class SetParent : IEgoEvent
 {
 	public readonly EgoComponent parent;
 	public readonly EgoComponent child;


### PR DESCRIPTION
This PR changes the base event abstract class (`EgoEvent`) to an interface (`IEgoEvent`).

Doing so allows custom event types to inherit from other classes such as Unity3D's [ScriptableObject](https://docs.unity3d.com/ScriptReference/ScriptableObject.html), allowing them to be created and used efficiently in the editor.

This PR also allows, at a small performance cost, to call `EgoEvents.AddEvent(IEgoEvent e)` and still have the event dispatched to the proper queue.

Example use case:

```C#
// ScriptableEgoEvent.cs

public class ScriptableEgoEvent : UnityEngine.ScriptableObject, IEgoEvent {}
```

```C#
// CustomEvent1.cs

using UnityEngine;

[CreateAssetMenu( fileName = "CustomEvent1", menuName = "EgoEvents/CustomEvent1" )]
public class CustomEven1t : ScriptableEgoEvent
{
    public string param;
}
```

```C#
// CustomEvent2.cs

using UnityEngine;

[CreateAssetMenu( fileName = "CustomEvent2", menuName = "EgoEvents/CustomEvent2" )]
public class CustomEven1t : ScriptableEgoEvent
{
    public int param;
}
```

```C#
// SomeComponent.cs

using UnityEngine;

[DisallowMultipleComponent]
public class SomeComponent: MonoBehaviour
{
    public ScriptableEgoEvent egoEvent;
}
```

```C#
// SomeSystem.cs
    ...
    public override void Start()
    {
        EgoEvents<CustomEvent2>.AddHandler( Handle );
    }
    ...
```

Events created using those menus can be dragged and dropped to components' public fields of type `ScriptableEgoEvent` and dispatched later on using `EgoEvents.AddEvent( component.egoEvent )` to the proper queues.